### PR TITLE
Introduce Write(int, XlsxStyle) in Worksheet to handle integer values directly rather than rely on cast to double. Avoids double format call.

### DIFF
--- a/src/LargeXlsx/Worksheet.cs
+++ b/src/LargeXlsx/Worksheet.cs
@@ -209,6 +209,20 @@ namespace LargeXlsx
             CurrentColumnNumber++;
         }
 
+        public void Write(int value, XlsxStyle style)
+        {
+            EnsureRow();
+            // <c r="{0}{1}" s="{2}"><v>{3}</v></c>
+            _streamWriter.Write("<c");
+            WriteCellRef();
+            WriteStyle(style);
+            _streamWriter
+                .Append("><v>")
+                .Append(value)
+                .Append("</v></c>\n");
+            CurrentColumnNumber++;
+        }
+
         public void Write(bool value, XlsxStyle style)
         {
             EnsureRow();

--- a/src/LargeXlsx/XlsxWriter.cs
+++ b/src/LargeXlsx/XlsxWriter.cs
@@ -307,7 +307,14 @@ namespace LargeXlsx
 
         public XlsxWriter Write(int value, XlsxStyle style = null, int columnSpan = 1)
         {
-            return Write((double)value, style, columnSpan);
+            if (columnSpan == 1)
+            {
+                CheckInWorksheet();
+                _currentWorksheet.Write(value, style ?? DefaultStyle);
+                return this;
+            }
+
+            return AddMergedCell(1, columnSpan).Write(value, style, 1).Write(style, repeatCount: columnSpan - 1);
         }
 
         public XlsxWriter Write(DateTime value, XlsxStyle style = null, int columnSpan = 1)


### PR DESCRIPTION
Introduce Write(int, XlsxStyle) in Worksheet to handle integer values directly rather than rely on cast to double. Avoids double format call.