### PR TITLE
Swap Compression Library

### DIFF
--- a/Examples/Large.cs
+++ b/Examples/Large.cs
@@ -28,8 +28,8 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.IO.Compression;
 using LargeXlsx;
-using SharpCompress.Compressors.Deflate;
 
 namespace Examples;
 
@@ -54,7 +54,7 @@ public static class Large
     private static void DoRun(bool requireCellReferences)
     {
         using var stream = new FileStream($"{nameof(Large)}_{requireCellReferences}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Level3, requireCellReferences: requireCellReferences);
+        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Fastest, requireCellReferences: requireCellReferences);
         var whiteFont = new XlsxFont("Calibri", 11, Color.White, bold: true);
         var blueFill = new XlsxFill(Color.FromArgb(0, 0x45, 0x86));
         var headerStyle = new XlsxStyle(whiteFont, blueFill, XlsxBorder.None, XlsxNumberFormat.General, XlsxAlignment.Default);

--- a/Examples/StyledLarge.cs
+++ b/Examples/StyledLarge.cs
@@ -28,9 +28,9 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using LargeXlsx;
-using SharpCompress.Compressors.Deflate;
 
 namespace Examples;
 
@@ -57,7 +57,7 @@ public static class StyledLarge
     {
         var rnd = new Random();
         using var stream = new FileStream($"{nameof(StyledLarge)}_{requireCellReferences}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Level3, requireCellReferences: requireCellReferences);
+        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Fastest, requireCellReferences: requireCellReferences);
         var headerStyle = new XlsxStyle(
             new XlsxFont("Calibri", 11, Color.White, bold: true),
             new XlsxFill(Color.FromArgb(0, 0x45, 0x86)),

--- a/Examples/StyledLargeCreateStyles.cs
+++ b/Examples/StyledLargeCreateStyles.cs
@@ -28,6 +28,7 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using LargeXlsx;
 
@@ -56,7 +57,7 @@ public static class StyledLargeCreateStyles
     {
         var rnd = new Random();
         using var stream = new FileStream($"{nameof(StyledLargeCreateStyles)}_{requireCellReferences}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, requireCellReferences: requireCellReferences);
+        using var xlsxWriter = new XlsxWriter(stream, requireCellReferences: requireCellReferences, compressionLevel: CompressionLevel.Fastest);
         var colors = Enumerable.Repeat(0, 100).Select(_ => Color.FromArgb(rnd.Next(256), rnd.Next(256), rnd.Next(256))).ToList();
         var headerStyle = new XlsxStyle(
             new XlsxFont("Calibri", 10.5, Color.White, bold: true),

--- a/Examples/Zip64Huge.cs
+++ b/Examples/Zip64Huge.cs
@@ -41,7 +41,7 @@ public static class Zip64Huge
     {
         var stopwatch = Stopwatch.StartNew();
         using (var stream = new FileStream($"{nameof(Zip64Huge)}.xlsx", FileMode.Create, FileAccess.Write))
-        using (var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Fastest, useZip64: true))
+        using (var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Fastest))
         {
             xlsxWriter.BeginWorksheet("Sheet1", 1, 1);
             xlsxWriter.BeginRow();

--- a/Examples/Zip64Huge.cs
+++ b/Examples/Zip64Huge.cs
@@ -27,8 +27,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using LargeXlsx;
-using SharpCompress.Compressors.Deflate;
 
 namespace Examples;
 
@@ -41,7 +41,7 @@ public static class Zip64Huge
     {
         var stopwatch = Stopwatch.StartNew();
         using (var stream = new FileStream($"{nameof(Zip64Huge)}.xlsx", FileMode.Create, FileAccess.Write))
-        using (var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.BestSpeed, useZip64: true))
+        using (var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Fastest, useZip64: true))
         {
             xlsxWriter.BeginWorksheet("Sheet1", 1, 1);
             xlsxWriter.BeginRow();

--- a/Examples/Zip64Small.cs
+++ b/Examples/Zip64Small.cs
@@ -35,7 +35,7 @@ public static class Zip64Small
     public static void Run()
     {
         using var stream = new FileStream($"{nameof(Zip64Small)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Fastest, useZip64: true);
+        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Fastest);
         xlsxWriter.BeginWorksheet("Sheet1").BeginRow().Write("A1").Write("B1").BeginRow().Write("A2").Write("B2");
     }
 }

--- a/Examples/Zip64Small.cs
+++ b/Examples/Zip64Small.cs
@@ -25,8 +25,8 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 using System.IO;
+using System.IO.Compression;
 using LargeXlsx;
-using SharpCompress.Compressors.Deflate;
 
 namespace Examples;
 
@@ -35,7 +35,7 @@ public static class Zip64Small
     public static void Run()
     {
         using var stream = new FileStream($"{nameof(Zip64Small)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.BestSpeed, useZip64: true);
+        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Fastest, useZip64: true);
         xlsxWriter.BeginWorksheet("Sheet1").BeginRow().Write("A1").Write("B1").BeginRow().Write("A2").Write("B2");
     }
 }

--- a/LargeXlsx.Tests/XlsxWriterTest.cs
+++ b/LargeXlsx.Tests/XlsxWriterTest.cs
@@ -388,10 +388,10 @@ public static class XlsxWriterTest
     }
 
     [Theory]
-    public static void Zip64(bool useZip64)
+    public static void Zip64()
     {
         using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream, useZip64: useZip64))
+        using (var xlsxWriter = new XlsxWriter(stream))
         {
             xlsxWriter
                 .BeginWorksheet("Sheet1")

--- a/LargeXlsx/LargeXlsx.csproj
+++ b/LargeXlsx/LargeXlsx.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpCompress" Version="0.39.0" />
     <None Include="../LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
   </ItemGroup>
 

--- a/LargeXlsx/SharedStringTable.cs
+++ b/LargeXlsx/SharedStringTable.cs
@@ -26,9 +26,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
-using SharpCompress.Writers.Zip;
 
 namespace LargeXlsx
 {
@@ -55,16 +55,15 @@ namespace LargeXlsx
             return id;
         }
 
-        public void Save(ZipWriter zipWriter)
+        public void Save(ZipArchive zipArchive)
         {
-            using (var stream = zipWriter.WriteToStream("xl/sharedStrings.xml", new ZipWriterEntryOptions()))
-            using (var streamWriter = new StreamWriter(stream, Encoding.UTF8))
+            var entry = zipArchive.CreateEntry("xl/sharedStrings.xml", CompressionLevel.Optimal);
+            using (var streamWriter = new StreamWriter(entry.Open(), Encoding.UTF8))
             {
                 streamWriter.WriteLine("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
                                    + "<sst xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">");
                 foreach (var si in _stringItems.OrderBy(s => s.Value))
                 {
-                    // <si><t xml:space="preserve">{0}</t></si>
                     streamWriter
                         .Append("<si><t")
                         .AddSpacePreserveIfNeeded(si.Key)

--- a/LargeXlsx/SharedStringTable.cs
+++ b/LargeXlsx/SharedStringTable.cs
@@ -55,9 +55,9 @@ namespace LargeXlsx
             return id;
         }
 
-        public void Save(ZipArchive zipArchive)
+        public void Save(ZipArchive zipArchive, CompressionLevel compressionLevel)
         {
-            var entry = zipArchive.CreateEntry("xl/sharedStrings.xml", CompressionLevel.Optimal);
+            var entry = zipArchive.CreateEntry("xl/sharedStrings.xml", compressionLevel);
             using (var streamWriter = new StreamWriter(entry.Open(), Encoding.UTF8))
             {
                 streamWriter.WriteLine("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"

--- a/LargeXlsx/Stylesheet.cs
+++ b/LargeXlsx/Stylesheet.cs
@@ -108,9 +108,9 @@ namespace LargeXlsx
             return id;
         }
 
-        public void Save(ZipArchive zipArchive)
+        public void Save(ZipArchive zipArchive, CompressionLevel compressionLevel)
         {
-            var entry = zipArchive.CreateEntry("xl/styles.xml", CompressionLevel.Optimal);
+            var entry = zipArchive.CreateEntry("xl/styles.xml", compressionLevel);
             using (var streamWriter = new InvariantCultureStreamWriter(entry.Open()))
             {
                 streamWriter.WriteLine("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"

--- a/LargeXlsx/Stylesheet.cs
+++ b/LargeXlsx/Stylesheet.cs
@@ -27,8 +27,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
-using SharpCompress.Writers.Zip;
 
 namespace LargeXlsx
 {
@@ -108,10 +108,10 @@ namespace LargeXlsx
             return id;
         }
 
-        public void Save(ZipWriter zipWriter)
+        public void Save(ZipArchive zipArchive)
         {
-            using (var stream = zipWriter.WriteToStream("xl/styles.xml", new ZipWriterEntryOptions()))
-            using (var streamWriter = new InvariantCultureStreamWriter(stream))
+            var entry = zipArchive.CreateEntry("xl/styles.xml", CompressionLevel.Optimal);
+            using (var streamWriter = new InvariantCultureStreamWriter(entry.Open()))
             {
                 streamWriter.WriteLine("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
                                    + "<styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">");

--- a/LargeXlsx/Worksheet.cs
+++ b/LargeXlsx/Worksheet.cs
@@ -28,8 +28,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
-using SharpCompress.Writers.Zip;
 
 namespace LargeXlsx
 {
@@ -60,7 +60,7 @@ namespace LargeXlsx
         internal string AutoFilterAbsoluteRef => _autoFilterAbsoluteRef;
 
         public Worksheet(
-            ZipWriter zipWriter,
+            ZipArchive zipArchive,
             int id,
             string name,
             int splitRow,
@@ -88,7 +88,8 @@ namespace LargeXlsx
             _pageBreakRowNumbers = new HashSet<int>();
             _pageBreakColumnNumbers = new HashSet<int>();
             _cellRefsByDataValidation = new Dictionary<XlsxDataValidation, List<string>>();
-            _stream = zipWriter.WriteToStream($"xl/worksheets/sheet{id}.xml", new ZipWriterEntryOptions());
+            var entry = zipArchive.CreateEntry($"xl/worksheets/sheet{id}.xml", CompressionLevel.Optimal);
+            _stream = entry.Open();
             _streamWriter = new InvariantCultureStreamWriter(_stream);
 
             _streamWriter.Write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"

--- a/LargeXlsx/Worksheet.cs
+++ b/LargeXlsx/Worksheet.cs
@@ -61,6 +61,7 @@ namespace LargeXlsx
 
         public Worksheet(
             ZipArchive zipArchive,
+            CompressionLevel compressionLevel,
             int id,
             string name,
             int splitRow,
@@ -88,7 +89,7 @@ namespace LargeXlsx
             _pageBreakRowNumbers = new HashSet<int>();
             _pageBreakColumnNumbers = new HashSet<int>();
             _cellRefsByDataValidation = new Dictionary<XlsxDataValidation, List<string>>();
-            var entry = zipArchive.CreateEntry($"xl/worksheets/sheet{id}.xml", CompressionLevel.Optimal);
+            var entry = zipArchive.CreateEntry($"xl/worksheets/sheet{id}.xml", compressionLevel);
             _stream = entry.Open();
             _streamWriter = new InvariantCultureStreamWriter(_stream);
 

--- a/LargeXlsx/XlsxWriter.cs
+++ b/LargeXlsx/XlsxWriter.cs
@@ -46,7 +46,7 @@ namespace LargeXlsx
         private Worksheet _currentWorksheet;
         private bool _hasFormulasWithoutResult;
         private bool _disposed;
-        private CompressionLevel _compressionLevel;
+        private readonly CompressionLevel _compressionLevel;
 
         public XlsxStyle DefaultStyle { get; private set; }
         public int CurrentRowNumber => _currentWorksheet.CurrentRowNumber;

--- a/LargeXlsx/XlsxWriter.cs
+++ b/LargeXlsx/XlsxWriter.cs
@@ -27,20 +27,17 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using SharpCompress.Common;
-using SharpCompress.Compressors.Deflate;
-using SharpCompress.Writers;
-using SharpCompress.Writers.Zip;
 
 namespace LargeXlsx
 {
     public sealed class XlsxWriter : IDisposable
     {
         private const int MaxSheetNameLength = 31;
-        private readonly ZipWriter _zipWriter;
+        private readonly ZipArchive _zipArchive;
         private readonly List<Worksheet> _worksheets;
         private readonly Stylesheet _stylesheet;
         private readonly SharedStringTable _sharedStringTable;
@@ -57,7 +54,7 @@ namespace LargeXlsx
         public string GetRelativeColumnName(int offsetFromCurrentColumn) => Util.GetColumnName(CurrentColumnNumber + offsetFromCurrentColumn);
         public static string GetColumnName(int columnIndex) => Util.GetColumnName(columnIndex);
 
-        public XlsxWriter(Stream stream, CompressionLevel compressionLevel = CompressionLevel.Level3, bool useZip64 = false, bool requireCellReferences = true, bool skipInvalidCharacters = false)
+        public XlsxWriter(Stream stream, CompressionLevel compressionLevel = CompressionLevel.Optimal, bool useZip64 = false, bool requireCellReferences = true, bool skipInvalidCharacters = false)
         {
             _worksheets = new List<Worksheet>();
             _stylesheet = new Stylesheet();
@@ -66,7 +63,7 @@ namespace LargeXlsx
             _skipInvalidCharacters = skipInvalidCharacters;
             DefaultStyle = XlsxStyle.Default;
 
-            _zipWriter = (ZipWriter)WriterFactory.Open(stream, ArchiveType.Zip, new ZipWriterOptions(CompressionType.Deflate) { DeflateCompressionLevel = compressionLevel, UseZip64 = useZip64 });
+            _zipArchive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: false);
         }
 
         public void Dispose()
@@ -74,14 +71,14 @@ namespace LargeXlsx
             if (!_disposed)
             {
                 _currentWorksheet?.Dispose();
-                _stylesheet.Save(_zipWriter);
-                _sharedStringTable.Save(_zipWriter);
+                _stylesheet.Save(_zipArchive);
+                _sharedStringTable.Save(_zipArchive);
                 SaveDocProps();
                 SaveContentTypes();
                 SaveRels();
                 SaveWorkbook();
                 SaveWorkbookRels();
-                _zipWriter.Dispose();
+                _zipArchive.Dispose();
                 _disposed = true;
             }
         }
@@ -89,8 +86,8 @@ namespace LargeXlsx
         private void SaveDocProps()
         {
             var assemblyName = Assembly.GetExecutingAssembly().GetName();
-            using (var stream = _zipWriter.WriteToStream("docProps/app.xml", new ZipWriterEntryOptions()))
-            using (var streamWriter = new StreamWriter(stream, Encoding.UTF8))
+            var entry = _zipArchive.CreateEntry("docProps/app.xml", CompressionLevel.Optimal);
+            using (var streamWriter = new StreamWriter(entry.Open(), Encoding.UTF8))
             {
                 // Looks some applications (e.g. Microsoft's) may consider a file invalid if a specific version number is not found.
                 // Thus, pretend being version 15.0 like LibreOffice Calc does.
@@ -107,8 +104,8 @@ namespace LargeXlsx
 
         private void SaveContentTypes()
         {
-            using (var stream = _zipWriter.WriteToStream("[Content_Types].xml", new ZipWriterEntryOptions()))
-            using (var streamWriter = new StreamWriter(stream, Encoding.UTF8))
+            var entry = _zipArchive.CreateEntry("[Content_Types].xml", CompressionLevel.Optimal);
+            using (var streamWriter = new StreamWriter(entry.Open(), Encoding.UTF8))
             {
                 var worksheetTags = new StringBuilder();
                 foreach (var worksheet in _worksheets)
@@ -130,8 +127,8 @@ namespace LargeXlsx
 
         private void SaveRels()
         {
-            using (var stream = _zipWriter.WriteToStream("_rels/.rels", new ZipWriterEntryOptions()))
-            using (var streamWriter = new StreamWriter(stream, Encoding.UTF8))
+            var entry = _zipArchive.CreateEntry("_rels/.rels", CompressionLevel.Optimal);
+            using (var streamWriter = new StreamWriter(entry.Open(), Encoding.UTF8))
             {
                 streamWriter.Write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
                                    + "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
@@ -143,8 +140,8 @@ namespace LargeXlsx
 
         private void SaveWorkbook()
         {
-            using (var stream = _zipWriter.WriteToStream("xl/workbook.xml", new ZipWriterEntryOptions()))
-            using (var streamWriter = new StreamWriter(stream, Encoding.UTF8))
+            var entry = _zipArchive.CreateEntry("xl/workbook.xml", CompressionLevel.Optimal);
+            using (var streamWriter = new StreamWriter(entry.Open(), Encoding.UTF8))
             {
                 var worksheetTags = new StringWriter();
                 var definedNames = new StringWriter();
@@ -192,8 +189,8 @@ namespace LargeXlsx
 
         private void SaveWorkbookRels()
         {
-            using (var stream = _zipWriter.WriteToStream("xl/_rels/workbook.xml.rels", new ZipWriterEntryOptions()))
-            using (var streamWriter = new StreamWriter(stream, Encoding.UTF8))
+            var entry = _zipArchive.CreateEntry("xl/_rels/workbook.xml.rels", CompressionLevel.Optimal);
+            using (var streamWriter = new StreamWriter(entry.Open(), Encoding.UTF8))
             {
                 var worksheetTags = new StringBuilder();
                 foreach (var worksheet in _worksheets)
@@ -223,7 +220,7 @@ namespace LargeXlsx
                 throw new ArgumentException($"A worksheet named \"{name}\" has already been added");
             _currentWorksheet?.Dispose();
             _currentWorksheet = new Worksheet(
-                zipWriter: _zipWriter,
+                zipArchive: _zipArchive,
                 id: _worksheets.Count + 1,
                 name: name,
                 splitRow: splitRow,

--- a/LargeXlsx/XlsxWriter.cs
+++ b/LargeXlsx/XlsxWriter.cs
@@ -63,7 +63,7 @@ namespace LargeXlsx
             _skipInvalidCharacters = skipInvalidCharacters;
             DefaultStyle = XlsxStyle.Default;
 
-            _zipArchive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: false);
+            _zipArchive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true);
         }
 
         public void Dispose()


### PR DESCRIPTION
Following up on an idea from otykier, this PR replaces Sharp.Compress with System.IO.Compression. All tests and examples run (with significant performance gains in my ad-hoc benchmarks). I have also tested that the huge archives can be opened in Excel. There are breaking changes in the XlsxWriter constructor because of the use of a different CompressionLevel enum and dropping the Zip64 flag (which is handled internally by the library)